### PR TITLE
Update readme for .clone method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ const seedrandom = require('seedrandom')
 random.use(seedrandom('foobar'))
 
 // create a new independent random number generator (uses seedrandom under the hood)
-const rng = random.clone('my-new-seed')
+const rng = random.clone('default', 'my-new-seed')
 
 // create a second independent random number generator and use a seeded PRNG
 const rng2 = random.clone(seedrandom('kittyfoo'))

--- a/src/random.js
+++ b/src/random.js
@@ -54,6 +54,7 @@ class Random {
    *
    * @see RNG.clone
    *
+   * @param {RNG|function|string|number} [rng='default'] - Optional pseudorandom number generator.
    * @param {string} [seed] - Optional seed for new RNG.
    * @param {object} [opts] - Optional config for new RNG options.
    * @return {Random}


### PR DESCRIPTION
Hello,   
I recently started use this package, and after some try-and-error experiments I've noticed the [basic usage example][1] for `.clone()` is broken (see last section of the code examples): Although it states I can use it with a single `seed` parameter, in reality the first argument will be the used pseudorandom number generator as of `rng-factory`:

https://github.com/transitive-bullshit/random/blob/e914f3dc83edf00ef2e5c86a7b653365e4c48573/src/rng-factory.js#L7-L26

(Notice the first parameter will be used to determine the nature of the rng, while the _rest_ will be used as argument for the generator itself)

Due to this I updated the documentation to reflect the behaviour and make it clearer what's happening during the `.clone()`

Please review and merge it accordingly!

[1]: https://github.com/pcdevil/random/blob/master/readme.md#usage