### PR TITLE
feat: Adding custom validation, removing ow

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "bates"
   ],
   "dependencies": {
-    "ow": "^0.23.0",
     "seedrandom": "^3.0.5"
   },
   "devDependencies": {

--- a/src/NumberValidator.ts
+++ b/src/NumberValidator.ts
@@ -1,0 +1,45 @@
+export class NumberValidator {
+  private n: number
+  constructor(num: number) {
+    this.n = num
+  }
+
+  public isInt = (): this => {
+    if (Number.isInteger(this.n)) {
+      return this
+    }
+    throw new Error(`Expected number to be an integer, got ${this.n}`)
+  }
+
+  public isPositive = (): this => {
+    if (this.n > 0) {
+      return this
+    }
+    throw new Error(`Expected number to be positive, got ${this.n}`)
+  }
+
+  public lessThan = (v: number): this => {
+    if (this.n < v) {
+      return this
+    }
+    throw new Error(`Expected number to be less than ${v}, got ${this.n}`)
+  }
+
+  public greaterThanOrEqual = (v: number): this => {
+    if (this.n >= v) {
+      return this
+    }
+    throw new Error(
+      `Expected number to be greater than or equal to ${v}, got ${this.n}`
+    )
+  }
+
+  public greaterThan = (v: number): this => {
+    if (this.n > v) {
+      return this
+    }
+    throw new Error(`Expected number to be greater than ${v}, got ${this.n}`)
+  }
+}
+
+export default NumberValidator

--- a/src/distributions/bates.ts
+++ b/src/distributions/bates.ts
@@ -1,6 +1,5 @@
-// import ow from 'ow'
 import { Random } from '../random'
-import { NumberValidator } from '../NumberValidator'
+import NumberValidator from '../NumberValidator'
 
 export default (random: Random, n = 1) => {
   new NumberValidator(n).isInt().isPositive()

--- a/src/distributions/bates.ts
+++ b/src/distributions/bates.ts
@@ -1,8 +1,9 @@
-import ow from 'ow'
+// import ow from 'ow'
 import { Random } from '../random'
+import { NumberValidator } from '../NumberValidator'
 
 export default (random: Random, n = 1) => {
-  ow(n, ow.number.integer.positive)
+  new NumberValidator(n).isInt().isPositive()
   const irwinHall = random.irwinHall(n)
 
   return () => {

--- a/src/distributions/bernoulli.ts
+++ b/src/distributions/bernoulli.ts
@@ -1,8 +1,9 @@
-import ow from 'ow'
 import { Random } from '../random'
+import NumberValidator from '../NumberValidator'
 
 export default (random: Random, p = 0.5) => {
-  ow(p, ow.number.greaterThanOrEqual(0).lessThan(1))
+  new NumberValidator(p).greaterThanOrEqual(0).lessThan(1)
+
   return () => {
     return (random.next() + p) | 0
   }

--- a/src/distributions/binomial.ts
+++ b/src/distributions/binomial.ts
@@ -1,9 +1,9 @@
-import ow from 'ow'
 import { Random } from '../random'
+import NumberValidator from '../NumberValidator'
 
 export default (random: Random, n = 1, p = 0.5) => {
-  ow(n, ow.number.positive.integer)
-  ow(p, ow.number.greaterThanOrEqual(0).lessThan(1))
+  new NumberValidator(n).isInt().isPositive()
+  new NumberValidator(p).greaterThanOrEqual(0).lessThan(1)
 
   return () => {
     let i = 0

--- a/src/distributions/exponential.ts
+++ b/src/distributions/exponential.ts
@@ -1,8 +1,8 @@
-import ow from 'ow'
 import { Random } from '../random'
+import NumberValidator from '../NumberValidator'
 
 export default (random: Random, lambda = 1) => {
-  ow(lambda, ow.number.positive)
+  new NumberValidator(lambda).isPositive()
   return () => {
     return -Math.log(1 - random.next()) / lambda
   }

--- a/src/distributions/geometric.ts
+++ b/src/distributions/geometric.ts
@@ -1,8 +1,8 @@
-import ow from 'ow'
 import { Random } from '../random'
+import NumberValidator from '../NumberValidator'
 
 export default (random: Random, p = 0.5) => {
-  ow(p, ow.number.greaterThan(0).lessThan(1))
+  new NumberValidator(p).greaterThan(0).lessThan(1)
   const invLogP = 1.0 / Math.log(1.0 - p)
   return () => {
     return (1 + Math.log(random.next()) * invLogP) | 0

--- a/src/distributions/irwin-hall.ts
+++ b/src/distributions/irwin-hall.ts
@@ -1,8 +1,8 @@
-import ow from 'ow'
 import { Random } from '../random'
+import NumberValidator from '../NumberValidator'
 
 export default (random: Random, n = 1) => {
-  ow(n, ow.number.integer.greaterThanOrEqual(0))
+  new NumberValidator(n).isInt().greaterThanOrEqual(0)
 
   return () => {
     let sum = 0

--- a/src/distributions/pareto.ts
+++ b/src/distributions/pareto.ts
@@ -1,8 +1,8 @@
-import ow from 'ow'
 import { Random } from '../random'
+import NumberValidator from '../NumberValidator'
 
 export default (random: Random, alpha = 1) => {
-  ow(alpha, ow.number.greaterThanOrEqual(0))
+  new NumberValidator(alpha).greaterThanOrEqual(0)
   const invAlpha = 1.0 / alpha
 
   return () => {

--- a/src/distributions/poisson.ts
+++ b/src/distributions/poisson.ts
@@ -1,5 +1,5 @@
-import ow from 'ow'
 import { Random } from '../random'
+import NumberValidator from '../NumberValidator'
 
 const logFactorialTable = [
   0.0,
@@ -21,7 +21,7 @@ const logFactorial = (k: number) => {
 const logSqrt2PI = 0.91893853320467267
 
 export default (random: Random, lambda = 1) => {
-  ow(lambda, ow.number.positive)
+  new NumberValidator(lambda).isPositive()
 
   if (lambda < 10) {
     // inversion method

--- a/src/distributions/uniform-int.ts
+++ b/src/distributions/uniform-int.ts
@@ -1,5 +1,5 @@
 import { Random } from '../random'
-import ow from 'ow'
+import NumberValidator from '../NumberValidator'
 
 export default (random: Random, min = 0, max = 1) => {
   if (max === undefined) {
@@ -7,8 +7,8 @@ export default (random: Random, min = 0, max = 1) => {
     min = 0
   }
 
-  ow(min, ow.number.integer)
-  ow(max, ow.number.integer)
+  new NumberValidator(min).isInt()
+  new NumberValidator(max).isInt()
 
   return () => {
     return (random.next() * (max - min + 1) + min) | 0

--- a/src/generators/function.ts
+++ b/src/generators/function.ts
@@ -1,4 +1,3 @@
-import ow from 'ow'
 import RNG, { SeedFn } from '../rng'
 
 export default class RNGFunction extends RNG {
@@ -20,7 +19,6 @@ export default class RNGFunction extends RNG {
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   seed(thunk: SeedFn, _opts?: Record<string, unknown>) {
-    ow(thunk, ow.function)
     this._rng = thunk
   }
 

--- a/test/distributions/bates.test.ts
+++ b/test/distributions/bates.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava'
-import { ArgumentError } from 'ow'
 import seedrandom from 'seedrandom'
 import random from '../../src/random'
 
@@ -19,7 +18,7 @@ test('random.bates() invalid n float input', (t) => {
     () => {
       r.bates(1.3)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
 
   t.is(error.message, 'Expected number to be an integer, got 1.3')
@@ -32,7 +31,7 @@ test('random.bates() invalid negative n input', (t) => {
     () => {
       r.bates(-1)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
 
   t.is(error.message, 'Expected number to be positive, got -1')

--- a/test/distributions/bernoulli.test.ts
+++ b/test/distributions/bernoulli.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava'
-import { ArgumentError } from 'ow'
 import seedrandom from 'seedrandom'
 
 import random from '../../src/random'
@@ -19,7 +18,7 @@ test('random.bernoulli() p number input', (t) => {
     () => {
       r.bernoulli(3)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(error.message, 'Expected number to be less than 1, got 3')
 })
@@ -30,7 +29,7 @@ test('random.bernoulli() invalid p negative input', (t) => {
     () => {
       r.bernoulli(-1)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(
     error.message,

--- a/test/distributions/binomial.test.ts
+++ b/test/distributions/binomial.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava'
-import { ArgumentError } from 'ow'
 import seedrandom from 'seedrandom'
 
 import random from '../../src/random'
@@ -19,7 +18,7 @@ test('random.binomial() invalid negative n input', (t) => {
     () => {
       r.binomial(-1)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(error.message, 'Expected number to be positive, got -1')
 })
@@ -30,7 +29,7 @@ test('random.binomial() invalid positive p input', (t) => {
     () => {
       r.binomial(1, 3)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(error.message, 'Expected number to be less than 1, got 3')
 })

--- a/test/distributions/exponential.test.ts
+++ b/test/distributions/exponential.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava'
-import { ArgumentError } from 'ow'
 import seedrandom from 'seedrandom'
 
 import random from '../../src/random'
@@ -19,7 +18,7 @@ test('random.exponential() invalid negative n input', (t) => {
     () => {
       r.exponential(-1)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(error.message, 'Expected number to be positive, got -1')
 })

--- a/test/distributions/geometric.test.ts
+++ b/test/distributions/geometric.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava'
-import { ArgumentError } from 'ow'
 import seedrandom from 'seedrandom'
 
 import random from '../../src/random'
@@ -19,7 +18,7 @@ test('random.geometric() invalid positive n input', (t) => {
     () => {
       r.geometric(2)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(error.message, 'Expected number to be less than 1, got 2')
 })
@@ -30,7 +29,7 @@ test('random.geometric() invalid negative n input', (t) => {
     () => {
       r.geometric(-1)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(error.message, 'Expected number to be greater than 0, got -1')
 })

--- a/test/distributions/irwinHall.test.ts
+++ b/test/distributions/irwinHall.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava'
-import { ArgumentError } from 'ow'
 import seedrandom from 'seedrandom'
 
 import random from '../../src/random'
@@ -19,7 +18,7 @@ test('random.irwinHall() invalid negative n input', (t) => {
     () => {
       r.irwinHall(-1)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(
     error.message,

--- a/test/distributions/pareto.test.ts
+++ b/test/distributions/pareto.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava'
-import { ArgumentError } from 'ow'
 import seedrandom from 'seedrandom'
 
 import random from '../../src/random'
@@ -17,9 +16,9 @@ test('random.pareto() invalid negative n input', (t) => {
   const r = random.clone(seedrandom('ZDJjM2IyNmFlNmVjNWQwMGZkMmY1Y2Nk'))
   const error = t.throws(
     () => {
-      r.irwinHall(-1)
+      r.pareto(-1)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(
     error.message,

--- a/test/distributions/poisson.test.ts
+++ b/test/distributions/poisson.test.ts
@@ -1,5 +1,4 @@
 import test from 'ava'
-import { ArgumentError } from 'ow'
 import seedrandom from 'seedrandom'
 
 import random from '../../src/random'
@@ -19,7 +18,7 @@ test('random.poisson() invalid negative n input', (t) => {
     () => {
       r.poisson(-1)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(error.message, 'Expected number to be positive, got -1')
 })

--- a/test/distributions/uniform-int.test.ts
+++ b/test/distributions/uniform-int.test.ts
@@ -3,7 +3,6 @@ import seedrandom from 'seedrandom'
 
 import inDelta from '../_in-delta'
 import random from '../../src/random'
-import { ArgumentError } from 'ow'
 
 type distFn = () => number
 
@@ -50,7 +49,7 @@ test('random.uniformInt(min, max) with non valid input', (t) => {
     () => {
       r.uniformInt(10.1, 42.1)
     },
-    { instanceOf: ArgumentError }
+    { instanceOf: Error }
   )
   t.is(error.message, 'Expected number to be an integer, got 10.1')
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,11 +103,6 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz"
 
-"@sindresorhus/is@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.0.tgz#2ff674e9611b45b528896d820d3d7a812de2f0e4"
-  integrity sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==
-
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz"
@@ -2157,13 +2152,6 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-dot-prop@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-6.0.1.tgz#fc26b3cf142b9e59b74dbd39ed66ce620c681083"
-  integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
-  dependencies:
-    is-obj "^2.0.0"
-
 duplexer2@^0.1.2, duplexer2@~0.1.0:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer2/-/duplexer2-0.1.4.tgz"
@@ -3806,11 +3794,6 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
 lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz"
@@ -4381,18 +4364,6 @@ os-locale@^2.0.0:
 os-tmpdir@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-
-ow@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/ow/-/ow-0.23.0.tgz#2c3b270adad96886b4c916a38458a3586648993e"
-  integrity sha512-aAM7+00uoPXPIE1cmyh/3WJpzu2vihxymGYjpZl/MZ0OsCgVizJbCD4B5gm+/iMHvOmbdDCEIqtvSMqS9DLYcQ==
-  dependencies:
-    "@sindresorhus/is" "^4.0.0"
-    callsites "^3.1.0"
-    dot-prop "^6.0.1"
-    lodash.isequal "^4.5.0"
-    type-fest "^0.20.2"
-    vali-date "^1.0.0"
 
 p-cancelable@^0.4.0:
   version "0.4.1"
@@ -6097,11 +6068,6 @@ v8-compile-cache@^2.0.3:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
-
-vali-date@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/vali-date/-/vali-date-1.0.0.tgz#1b904a59609fb328ef078138420934f6b86709a6"
-  integrity sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=
 
 validate-npm-package-license@^3.0.1:
   version "3.0.3"


### PR DESCRIPTION
This pr introduces a custom number validation class to replace `ow`. The `NumberValidator` class has a similar api to `ow`. 

```typescript
new NumberValidator(n).isInt().isPositive()

// ow 
ow(n, ow.number.integer.positive)
```
This reduces the bundle size but is restrictive in that it only contains validations for the current distributions. I have an alternative pr that re introduces `ow-lite`, albeit with the absence of types. 

