### PR TITLE
fix #26: esm bundle issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 # builds
 build
 dist
+tsconfig.tsbuildinfo
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "3.0.3",
   "description": "Seedable random number generator supporting many common distributions.",
   "main": "dist/cjs/index.js",
-  "module": "dist/esm/index.js",
+  "module": "dist/esm/index.esm.js",
   "types": "dist/cjs/index.d.ts",
   "repository": "transitive-bullshit/random",
   "author": "Travis Fischer <travis@transitivebullsh.it>",

--- a/src/index.esm.ts
+++ b/src/index.esm.ts
@@ -1,0 +1,3 @@
+import random from './random'
+export * from './random'
+export default random

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
+  "exclude": ["**/index.esm.ts"],
   "compilerOptions": {
     "noEmit": false,
     "module": "commonjs",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "module": "commonjs",
-    "outDir": "dist/cjs"
-  }
+    "module": "es6",
+    "outDir": "dist/esm"
+  },
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,5 +1,6 @@
 {
   "extends": "./tsconfig.json",
+  "exclude": ["**/index.ts"],
   "compilerOptions": {
     "noEmit": false,
     "module": "es6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,15 +2,14 @@
   "compilerOptions": {
     "composite": true,
     "target": "es6",
-    "module": "commonjs",
     "moduleResolution": "node",
     "allowJs": true,
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "outDir": "dist/esm",
     "rootDir": "src",
     "strict": true,
+    "noEmit": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,
@@ -26,11 +25,14 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"],
+  "include": ["src"],
   "exclude": ["node_modules", "test"],
   "references": [
     {
       "path": "./tsconfig.cjs.json"
+    },
+    {
+      "path": "./tsconfig.esm.json"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src"],
+  "include": ["src/**/*"],
   "exclude": ["node_modules", "test"],
   "references": [
     {


### PR DESCRIPTION
Fix for #26 

Some of the necessary build files were only getting included in `dist/cjs` and not in `dist/esm`. This has been remedied by the addition of a `tsconfig.esm.json` to go with the `tsconfig.cjs.json`. The main `tsconfig.json` no longer emits any output, it acts as a base file that is extended upon in `tsconfig.esm.json` and `tsconfig.cjs.json`. 

While this allows for the inclusion of all necessary files in `dist/cjs` and `dist/esm`, there is still the issue of the entrypoint in `index.ts`. The cjs build needs the `module.exports = require('./random').default` but this causes errors when importing the package in a esm environment. The removal of this line fixes the esm importing  but causes import failure in a commonjs environment.  As a workaround I set the module entrypoint in package to point to a new index.esm.ts that doesn't contain  `module.exports = require('./random').default`. The main in package points to the current index.ts

I have tested this locally in a commonjs environment and in a modern react environment. Both are working fine. Tests are still passing. 

Given this issue I believe a better bundling system for random could be introduced with rollup. Let me know if you want me to tackle that.  
