### PR TITLE
Fix typescript types not working with node16 resolution environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "author": "Travis Fischer <travis@transitivebullsh.it>",
   "type": "module",
   "exports": {
-    "default": "./dist/random.module.js"
+		"import": "./dist/random.module.js",
+		"types": "./dist/index.d.ts",
+		"default": "./dist/random.module.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Description
When using `node16` module resolution in typescript, the types in the random library are not detected.

I found [this apparently identical issue](https://github.com/csandman/chakra-react-select/issues/187) in another library. Going off of their discussion, the `types` key at root level in the package.json is ignored when `exports` is present.

## Reproduction

1. Create a node/typescript project and install random.
2. Create a tsconfig with `"moduleResolution": "node16"`
3. Import random in a script
4. Run `tsc`

[Here's a minimal reproduction.](https://github.com/transitive-bullshit/random/files/10038668/random-import-typescript-node16-error.zip) Just run `npm i` and `tsc`.

## Proposed Solution

Changing
```json
"exports": {
  "default": "./dist/random.module.js"
},
```
to
```json
"exports": {
  "import": "./dist/random.module.js",
  "types": "./dist/index.d.ts",
  "default": "./dist/random.module.js"
},
```
resolves the issue.


