### PR TITLE
support p=1 for bernoulli

### DIFF
--- a/src/distributions/bernoulli.ts
+++ b/src/distributions/bernoulli.ts
@@ -2,9 +2,9 @@ import type { Random } from '../random'
 import { numberValidator } from '../validation'
 
 export function bernoulli(random: Random, p = 0.5) {
-  numberValidator(p).greaterThanOrEqual(0).lessThan(1)
+  numberValidator(p).greaterThanOrEqual(0).lessThanOrEqual(1)
 
   return () => {
-    return Math.floor(random.next() + p)
+    return Math.min(1, Math.floor(random.next() + p))
   }
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -29,6 +29,13 @@ export class NumberValidator {
     throw new Error(`Expected number to be less than ${v}, got ${this.n}`)
   }
 
+  public lessThanOrEqual = (v: number): this => {
+    if (this.n <= v) {
+      return this
+    }
+    throw new Error(`Expected number to be less than or equal to ${v}, got ${this.n}`)
+  }
+
   public greaterThanOrEqual = (v: number): this => {
     if (this.n >= v) {
       return this


### PR DESCRIPTION
Bernoulli(1) is a perfectly valid distribution and should be allowed. I added Math.min(1, ...) to handle the case where random.next returns exactly 1. Could avoid the rng call altogether by hardwiring the 0 and 1 case but I figure it's better for the resulting rng state to not depend on the p parameter.